### PR TITLE
feat(sol): Implement screen height calculator based on aspect ratio

### DIFF
--- a/FindScreenSizeApproach2.cpp
+++ b/FindScreenSizeApproach2.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <string>
+using namespace std;
+
+string find_screen_height(int width, const string &ratio)
+{
+  string result = "";
+  string str_width = to_string(width);
+  result += str_width + "x";
+  string ex1 = "";
+  string ex2 = "";
+  for (auto c : ratio)
+  {
+    if (c == ':')
+    {
+      break;
+    }
+    ex1 += c;
+  }
+  for (size_t i = 0; i <= ratio.length(); ++i)
+  {
+
+    if (ratio[i] == ':')
+    {
+      ex2 += ratio[i + 1];
+    }
+  }
+  cout << "extracted 1 = " << ex1 << "\n"; // debugging
+  cout << "extracted 2 = " << ex2 << "\n"; // debugging
+  int calc = (width * stoi(ex2)) / stoi(ex1);
+  string ratio_calc = to_string(calc);
+  result += ratio_calc;
+  return result;
+}
+
+int main()
+{
+  // int w = 434;
+  // string str_width = to_string(w);
+  // str_width += "s";
+  // cout << str_width;
+  // test case
+  cout << find_screen_height(1024, "4:3");
+  return 0;
+}


### PR DESCRIPTION
- Add function to calculate screen height from width and aspect ratio
- Parse aspect ratio string to extract numerator and denominator
- Calculate height using width and ratio components
- Return formatted string in 'widthxheight' format

adds Test case in the main program to ensure everyting work as expected for 1024x768 (4:3 ratio)